### PR TITLE
Fix the scaling issues on mobile devices

### DIFF
--- a/src/components/Canvas/CanvasBuilder.jsx
+++ b/src/components/Canvas/CanvasBuilder.jsx
@@ -4,7 +4,10 @@ import React, { useEffect, useRef } from 'react'
 import styles from './Canvas.module.css'
 
 /**
- * @typedef {(canvas: HTMLCanvasElement) => { draw: () => void, abort?: () => void }} DrawFactory
+ * @typedef  {Object} DrawFunctionConfig
+ * @property {number} scale Calculated from device's pixel ratio
+ *
+ * @typedef  {(canvas: HTMLCanvasElement, config?: DrawFunctionConfig) => { draw: () => void, abort?: () => void }} DrawFactory
  */
 
 export class CanvasBuilder {
@@ -53,21 +56,17 @@ export class CanvasBuilder {
         if (canvasRef.current != null) {
           const canvas = canvasRef.current
 
-          const width = Number(getComputedStyle(canvas)
-            .getPropertyValue('width')
-            .slice(0, -2))
-          const height = Number(getComputedStyle(canvas)
-            .getPropertyValue('height')
-            .slice(0, -2))
+          const width = Number.parseInt(getComputedStyle(canvas)
+            .getPropertyValue('width'))
+          const height = Number.parseInt(getComputedStyle(canvas)
+            .getPropertyValue('height'))
 
           // https://developer.mozilla.org/en-US/docs/Web/API/Window/devicePixelRatio
-          const ratio = window.devicePixelRatio ?? 1
-          canvas.width = width * ratio
-          canvas.height = height * ratio
-          canvas.style.width = `${width}px`
-          canvas.style.height = `${height}px`
+          const scale = window.devicePixelRatio ?? 1
+          canvas.width = width * scale
+          canvas.height = height * scale
 
-          const { draw, abort } = drawFactory(canvas)
+          const { draw, abort } = drawFactory(canvas, { scale })
 
           abortFn = abort
           draw()

--- a/src/components/Canvas/CanvasExample.jsx
+++ b/src/components/Canvas/CanvasExample.jsx
@@ -5,12 +5,17 @@ import { CanvasBuilder } from './CanvasBuilder'
 /**
  * @type {import('./CanvasBuilder').DrawFactory}
  */
-function drawExample (canvas) {
+function drawExample (canvas, { scale }) {
   return {
     draw () {
       const ctx = canvas.getContext('2d')
       ctx.fillStyle = 'green'
-      ctx.fillRect(0, 0, 100, 100)
+      ctx.fillRect(
+        0,
+        0,
+        100 * scale,
+        100 * scale
+      )
     }
   }
 }


### PR DESCRIPTION
## What

My Pixel phone scaled the example green square stupidly. This is because my phone's screen's pixel ratio is > 1 (probably 4). This did not affect the circle because its position and size are calculated based on the canvas' dimensions.

My solution: since we already have the device's pixel ratio to scale canvas drawings, we can provide it in a config object.

## Changes

- `DrawFactory` functions take an optional 2nd argument - a config object. That object currently only has 1 property: `scale`. We will almost certainly extend this with more properties as we build out more functionality.
- Minor tweaking of type definitions

![image](https://github.com/peterjmartinson/huygens-site/assets/17347977/5473a195-5519-4a75-a75b-114830b21450)
