### PR TITLE
Scalable header height and font

### DIFF
--- a/src/components/Header/Header.module.css
+++ b/src/components/Header/Header.module.css
@@ -1,10 +1,16 @@
 .header {
-  height: 82px;
+  --header-height-sm: 3rem;
+  --header-height-lg: 5rem;
+}
+
+.header {
+  height: var(--header-height-sm);
   background-color: var(--black);
   box-shadow: 1px 1px 5px 0 var(--gray);
   position: fixed;
   display: flex;
   justify-content: space-between;
+  align-items: center;
   top: 0;
   width: 100%;
 }
@@ -12,12 +18,13 @@
 .home {
   display: inline-block;
   color: var(--white);
-  font-size: 16px;
-  margin-left: 10px;
+  font-size: 0.625rem;
+  line-height: 0.625rem;
+  margin-left: 1rem;
 }
 
 .nav {
-  top: 82px;
+  top: var(--header-height-sm);
   width: 100%;
   height: 100%;
   position: fixed;
@@ -43,7 +50,7 @@
 
 .hamburger {
   cursor: pointer;
-  padding: 40px 20px;
+  padding: 1.25rem 1rem;
 }
 
 .hamburgerLine {
@@ -95,7 +102,16 @@
   top: 0;
 }
 
-@media (min-width: 768px) {
+@media (min-width: 800px) {
+  .header {
+    height: var(--header-height-lg);
+  }
+
+  .home {
+    font-size: 1rem;
+    line-height: 1rem;
+  }
+
   .nav {
     max-height: none;
     top: 0;

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -10,6 +10,7 @@ body {
   background-color: var(--white);
   padding: 0;
   margin: 0;
+  font-size: 16px;
   font-family: -apple-system, BlinkMacSystemFont, Segoe UI, Roboto, Oxygen,
     Ubuntu, Cantarell, Fira Sans, Droid Sans, Helvetica Neue, sans-serif;
 }


### PR DESCRIPTION
## What

Updates the `header` CSS to scale the header height and font and gutter sizes above / below 800px.

Resolves: https://github.com/peterjmartinson/huygens-site/issues/9

## Screenshots

800px and above:

![image](https://github.com/peterjmartinson/huygens-site/assets/17347977/819534f7-43f0-47d4-8250-b3fcea843b10)

Below 800px (fake iPhone SE)

![image](https://github.com/peterjmartinson/huygens-site/assets/17347977/6c39f1ac-b5a1-4472-bf1c-1eaf0baccfb0)
