### PR TITLE
feat: mechanism to add interactivity to canvases

### DIFF
--- a/src/components/Canvas/Circle.jsx
+++ b/src/components/Canvas/Circle.jsx
@@ -2,10 +2,15 @@
 
 import { CanvasBuilder } from './CanvasBuilder'
 
+const initialState = {
+  i: 0,
+  delta: 0.05
+}
+
 /** @type {import('./CanvasBuilder').DrawFactory} */
-function drawAnimatedCircle (canvas, { interval = 0, updateInterval }) {
+function drawAnimatedCircle (canvas, { drawState, setDrawState }) {
   let requestId
-  let i = interval
+  let { i, delta } = drawState
 
   /** @type {import('./CanvasBuilder').DrawFunction} */
   function draw ({ isPaused }) {
@@ -22,9 +27,10 @@ function drawAnimatedCircle (canvas, { interval = 0, updateInterval }) {
     )
     ctx.fill()
 
+    // if we're NOT paused, update i locally and in parent component
     if (!isPaused) {
-      i += 0.05
-      updateInterval(i)
+      i += delta
+      setDrawState({ i })
     }
 
     requestId = requestAnimationFrame(() => draw({ isPaused }))
@@ -42,4 +48,5 @@ function drawAnimatedCircle (canvas, { interval = 0, updateInterval }) {
 
 export const Circle = new CanvasBuilder()
   .withDrawFactory(drawAnimatedCircle)
+  .withInitialDrawState(initialState)
   .build()

--- a/src/components/Canvas/Circle.jsx
+++ b/src/components/Canvas/Circle.jsx
@@ -2,14 +2,13 @@
 
 import { CanvasBuilder } from './CanvasBuilder'
 
-/**
- * @type {import('./CanvasBuilder').DrawFactory}
- */
-function drawAnimatedCircle (canvas) {
+/** @type {import('./CanvasBuilder').DrawFactory} */
+function drawAnimatedCircle (canvas, { interval = 0, updateInterval }) {
   let requestId
-  let i = 0
+  let i = interval
 
-  function draw () {
+  /** @type {import('./CanvasBuilder').DrawFunction} */
+  function draw ({ isPaused }) {
     const ctx = canvas.getContext('2d')
 
     ctx.clearRect(0, 0, canvas.width, canvas.height)
@@ -22,8 +21,13 @@ function drawAnimatedCircle (canvas) {
       2 * Math.PI
     )
     ctx.fill()
-    i += 0.05
-    requestId = requestAnimationFrame(draw)
+
+    if (!isPaused) {
+      i += 0.05
+      updateInterval(i)
+    }
+
+    requestId = requestAnimationFrame(() => draw({ isPaused }))
   }
 
   function abort () {

--- a/src/components/Canvas/FallingBall.jsx
+++ b/src/components/Canvas/FallingBall.jsx
@@ -35,12 +35,13 @@ function drawFallingBall (canvas) {
     }
   }
 
+  /** @type {import('./CanvasBuilder').DrawFunction} */
   function draw () {
     ctx.clearRect(0, 0, canvas.width, canvas.height)
 
     ball.update()
     ball.create()
-    requestId = requestAnimationFrame(draw)
+    requestId = requestAnimationFrame(() => draw())
   }
 
   function abort () {

--- a/src/pages/about.js
+++ b/src/pages/about.js
@@ -1,7 +1,13 @@
+import { useState } from 'react'
 import Head from 'next/head'
+import { Circle } from '@/components/Canvas/Circle'
 import styles from '@/styles/Home.module.css'
 
 export default function Home () {
+  const [isPaused, setIsPaused] = useState(true)
+
+  const togglePause = () => setIsPaused(paused => !paused)
+
   return (
     <div className={styles.container}>
       <Head>
@@ -11,6 +17,12 @@ export default function Home () {
 
       <main className={styles.main}>
         <h2>ABOUT!</h2>
+
+        <button onClick={togglePause}>
+          {isPaused ? 'Unpause' : 'Pause'}
+        </button>
+
+        <Circle isPaused={isPaused} />
       </main>
     </div>
   )

--- a/src/pages/about.js
+++ b/src/pages/about.js
@@ -1,6 +1,7 @@
 import { useState } from 'react'
 import Head from 'next/head'
 import { Circle } from '@/components/Canvas/Circle'
+import { CanvasExample } from '@/components/Canvas/CanvasExample'
 import styles from '@/styles/Home.module.css'
 
 export default function Home () {
@@ -23,6 +24,7 @@ export default function Home () {
         </button>
 
         <Circle isPaused={isPaused} />
+        <CanvasExample />
       </main>
     </div>
   )

--- a/src/utils/is.js
+++ b/src/utils/is.js
@@ -1,0 +1,8 @@
+// @ts-check
+
+export const isObject = val => Object.prototype.toString.call(val) === '[object Object]'
+
+export const isFunction = val => (
+  Object.prototype.toString.call(val) === '[object Function]' ||
+  Object.prototype.toString.call(val) === '[object AsyncFunction]'
+)

--- a/src/utils/is.test.js
+++ b/src/utils/is.test.js
@@ -1,0 +1,41 @@
+import {
+  isFunction,
+  isObject
+} from './is'
+
+describe('isFunction', () => {
+  it.each([
+    [true, () => {}],
+    [true, async () => {}],
+    [true, function () {}],
+    [true, async function () {}],
+    [false, true],
+    [false, new Error()],
+    [false, []],
+    [false, 'anything'],
+    [false, 1],
+    [false, null],
+    [false, undefined]
+  ])('should return %p when passed %p', (expected, val) => {
+    expect(isFunction(val)).toBe(expected)
+  })
+})
+
+describe('isObject', () => {
+  it.each([
+    [true, Object.freeze({})],
+    [true, {}],
+    [false, new Error()],
+    [false, []],
+    [false, 'anything'],
+    [false, 1],
+    [false, null],
+    [false, () => {}],
+    [false, async () => {}],
+    [false, function () {}],
+    [false, async function () {}],
+    [false, undefined]
+  ])('should return %p when passed %p', (expected, val) => {
+    expect(isObject(val)).toBe(expected)
+  })
+})


### PR DESCRIPTION
This is in better shape now - OK to review.

### What

Adds new concept: **Draw State.**

The builder is updated to include a `.withInitialDrawState()` method. Use this to set initial conditions.

Draw state is a plain object that each canvas component can define for itself as `initialDrawState`. Draw state is a bucket of whatever you want - include stuff that you need to keep track of. If a canvas component does not define it, initial draw state defaults to an empty object `{}`.

Also, parent component `props` can be passed to the canvas component, which will pass them to `draw(props)`. See the `About` page changes for an example of passing an `isPaused` prop that changes based on button clicks. Prop changes trigger component re-renders, so we need to "persist" draw state across renders - the canvas should not reset on component re-render. Changing `ref`s does **not** trigger a re-render, hence I'm storing draw state in a ref.

Note: the way I've coded the _pause_ functionality, the animation loop does not stop. I just stop updating `i` when paused. The circle appears paused - it stops changing size - but it's just redrawing at the same size 60 times a second. This is deliberate and (I think) the idiomatic way to work with canvas animations.

A design goal: we should be able to define all these things in 1 file:
1. initial draw state
2. the draw factory
3. the canvas component

Closes https://github.com/peterjmartinson/huygens-site/issues/12

### Other Changes

* adds an `is.js` utility module that just exports predicate functions for checking whether a `val` _is_ some type.
* moves `CanvasExample` and `Circle` into the About page for demo purposes.

### Screenshots

I was a little nervous that calling `setDrawState` on each animation loop would crush performance. But I see a solid 60fps

![image](https://github.com/peterjmartinson/huygens-site/assets/17347977/793ba82a-31e8-4f88-8d77-8f20af477090)

