### PR TITLE
feat: control canvas dimensions

### DIFF
--- a/src/components/Canvas/Canvas.module.css
+++ b/src/components/Canvas/Canvas.module.css
@@ -1,4 +1,0 @@
-.canvas {
-  width: 100px;
-  height: 100px;
-}

--- a/src/drawings/circle/Circle.jsx
+++ b/src/drawings/circle/Circle.jsx
@@ -3,26 +3,26 @@
 import { CanvasBuilder } from '@/components/Canvas'
 import { Color } from '@/config'
 
+const HEIGHT = 100
+const WIDTH = 100
 const initialState = {
   i: 0,
   delta: 0.05
 }
 
 /** @type {import('@/components/Canvas/CanvasBuilder').DrawFactory} */
-function drawAnimatedCircle (canvas, { drawState, setDrawState }) {
+function drawAnimatedCircle (ctx, { drawState, setDrawState }) {
   let requestId
   let { i, delta } = drawState
 
   /** @type {import('@/components/Canvas/CanvasBuilder').DrawFunction} */
   function draw ({ isPaused }) {
-    const ctx = canvas.getContext('2d')
-
-    ctx.clearRect(0, 0, canvas.width, canvas.height)
+    ctx.clearRect(0, 0, WIDTH, HEIGHT)
     ctx.beginPath()
     ctx.arc(
-      canvas.width / 2,
-      canvas.height / 2,
-      (canvas.width / 2) * Math.abs(Math.cos(i)),
+      WIDTH / 2,
+      HEIGHT / 2,
+      (WIDTH / 2) * Math.abs(Math.cos(i)),
       0,
       2 * Math.PI
     )
@@ -49,6 +49,7 @@ function drawAnimatedCircle (canvas, { drawState, setDrawState }) {
 }
 
 export const Circle = new CanvasBuilder()
+  .withHeightAndWidth(HEIGHT, WIDTH)
   .withDrawFactory(drawAnimatedCircle)
   .withInitialDrawState(initialState)
   .build()

--- a/src/drawings/example/Example.jsx
+++ b/src/drawings/example/Example.jsx
@@ -3,22 +3,25 @@
 import { CanvasBuilder } from '@/components/Canvas'
 import { Color } from '@/config'
 
+const HEIGHT = 100
+const WIDTH = 100
+
 /** @type {import('@/components/Canvas/CanvasBuilder').DrawFactory} */
-function drawExample (canvas, { scale }) {
+function drawExample (ctx) {
   return {
     draw () {
-      const ctx = canvas.getContext('2d')
       ctx.fillStyle = Color.YELLOW
       ctx.fillRect(
         0,
         0,
-        100 * scale,
-        100 * scale
+        100,
+        100
       )
     }
   }
 }
 
 export const Example = new CanvasBuilder()
+  .withHeightAndWidth(HEIGHT, WIDTH)
   .withDrawFactory(drawExample)
   .build()

--- a/src/drawings/falling-ball/FallingBall.jsx
+++ b/src/drawings/falling-ball/FallingBall.jsx
@@ -3,16 +3,18 @@
 import { CanvasBuilder } from '@/components/Canvas'
 import { Physics, Color } from '@/config'
 
+const HEIGHT = 200
+const WIDTH = 100
+
 /** @type {import('@/components/Canvas/CanvasBuilder').DrawFactory} */
-function drawFallingBall (canvas) {
-  const ctx = canvas.getContext('2d')
+function drawFallingBall (ctx) {
   let requestId
 
-  const ground = ctx.canvas.height
+  const ground = HEIGHT
   const ball = {
     radius: 10,
     color: Color.BLUE,
-    position: { x: ctx.canvas.width / 2, y: 10 },
+    position: { x: WIDTH / 2, y: 10 },
     velocity: { x: 0, y: 0 },
     update () {
       this.velocity.x += Physics.GRAVITY.x
@@ -35,7 +37,7 @@ function drawFallingBall (canvas) {
 
   /** @type {import('@/components/Canvas/CanvasBuilder').DrawFunction} */
   function draw () {
-    ctx.clearRect(0, 0, canvas.width, canvas.height)
+    ctx.clearRect(0, 0, WIDTH, HEIGHT)
 
     ball.update()
     ball.create()
@@ -53,5 +55,6 @@ function drawFallingBall (canvas) {
 }
 
 export const FallingBall = new CanvasBuilder()
+  .withHeightAndWidth(HEIGHT, WIDTH)
   .withDrawFactory(drawFallingBall)
   .build()


### PR DESCRIPTION
### What

With this PR each drawing can control its canvas dimensions.

Additionally, draw functions no longer receive `canvas` arguments - they get the canvas `ctx`. Turns out, `ctx.canvas` is a read-only reference to the canvas object. So if we need to access canvas properties we still can.

### Why

1. The `CanvasBuilder` or its CSS styles should not hard code height and width.
2. Since the first thing all `draw` functions do is get context, let's just pass that in instead
3. Since we pass in context, we can pre-scale according to device pixel ratio