### PR TITLE
Adds more canvas attributes and tests

### DIFF
--- a/src/components/Canvas/CanvasBuilder.test.js
+++ b/src/components/Canvas/CanvasBuilder.test.js
@@ -1,0 +1,86 @@
+import { render, screen } from '@testing-library/react'
+import { CanvasBuilder } from './index'
+
+describe('CanvasBuilder', () => {
+  const mockId = 'TestCanvas'
+  const mockWidth = 123
+  const mockHeight = 456
+  const mockDrawFn = jest.fn()
+  const mockDrawFactory = jest.fn().mockReturnValue({
+    draw: mockDrawFn
+  })
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('should construct an object with correct methods', () => {
+    const {
+      withId,
+      withHeightAndWidth,
+      withDrawFactory,
+      withInitialDrawState
+    } = new CanvasBuilder()
+
+    expect(typeof withId).toBe('function')
+    expect(typeof withHeightAndWidth).toBe('function')
+    expect(typeof withDrawFactory).toBe('function')
+    expect(typeof withInitialDrawState).toBe('function')
+  })
+
+  it('should build a react component when provided valid builder parameters', () => {
+    const TestCanvas = new CanvasBuilder()
+      .withId(mockId)
+      .withHeightAndWidth(mockHeight, mockWidth)
+      .withDrawFactory(mockDrawFactory)
+      .build()
+
+    expect(TestCanvas.ariaRole).toBe('img')
+    expect(TestCanvas.id).toBe(mockId)
+    expect(TestCanvas.dataTestId).toBe('Canvas_' + mockId)
+
+    render(<TestCanvas />)
+
+    // should be accessible by role
+    expect(screen.getByRole(TestCanvas.ariaRole)).toBeInTheDocument()
+
+    // should be accessible by data-testid
+    expect(screen.getByTestId(TestCanvas.dataTestId)).toBeInTheDocument()
+    expect(mockDrawFactory).toHaveBeenCalledTimes(1)
+    expect(mockDrawFn).toHaveBeenCalledTimes(1)
+  })
+
+  it('should error on build when `id` is omitted', () => {
+    expect(
+      () => new CanvasBuilder()
+        .withDrawFactory(mockDrawFactory)
+        .build()
+    ).toThrow(/`id` {string} is required to build/gi)
+  })
+
+  it('should error on build when `id` is an empty string', () => {
+    expect(
+      () => new CanvasBuilder()
+        .withId('')
+        .withDrawFactory(mockDrawFactory)
+        .build()
+    ).toThrow(/`id` {string} is required to build/gi)
+  })
+
+  it('should error on build when `drawFactory` is omitted', () => {
+    expect(
+      () => new CanvasBuilder()
+        .withId(mockId)
+        .build()
+    ).toThrow(/`drawFactory` {function} is required to build/gi)
+  })
+
+  it('should error on build when `drawFactory` is not a function', () => {
+    expect(
+      () => new CanvasBuilder()
+        .withId(mockId)
+        .withDrawFactory('not a function')
+        .build()
+    ).toThrow(/`drawFactory` {function} is required to build/gi)
+  })
+})

--- a/src/components/Canvas/CanvasBuilder.test.js
+++ b/src/components/Canvas/CanvasBuilder.test.js
@@ -19,13 +19,15 @@ describe('CanvasBuilder', () => {
       withId,
       withHeightAndWidth,
       withDrawFactory,
-      withInitialDrawState
+      withInitialDrawState,
+      build
     } = new CanvasBuilder()
 
     expect(typeof withId).toBe('function')
     expect(typeof withHeightAndWidth).toBe('function')
     expect(typeof withDrawFactory).toBe('function')
     expect(typeof withInitialDrawState).toBe('function')
+    expect(typeof build).toBe('function')
   })
 
   it('should build a react component when provided valid builder parameters', () => {
@@ -35,19 +37,28 @@ describe('CanvasBuilder', () => {
       .withDrawFactory(mockDrawFactory)
       .build()
 
+    // should have correct static properties
     expect(TestCanvas.ariaRole).toBe('img')
     expect(TestCanvas.id).toBe(mockId)
     expect(TestCanvas.dataTestId).toBe('Canvas_' + mockId)
 
+    // render the component
     render(<TestCanvas />)
-
-    // should be accessible by role
-    expect(screen.getByRole(TestCanvas.ariaRole)).toBeInTheDocument()
 
     // should be accessible by data-testid
     expect(screen.getByTestId(TestCanvas.dataTestId)).toBeInTheDocument()
-    expect(mockDrawFactory).toHaveBeenCalledTimes(1)
-    expect(mockDrawFn).toHaveBeenCalledTimes(1)
+
+    // should be accessible by role
+    const element = screen.getByRole(TestCanvas.ariaRole)
+
+    // should have the attributes we passed to the builder
+    expect(element).toHaveAttribute('height', String(mockHeight))
+    expect(element).toHaveAttribute('width', String(mockWidth))
+    expect(element).toHaveAttribute('id', mockId)
+
+    // component should have 1) called our drawFactory, and 2) called it's draw() method
+    expect(mockDrawFactory).toHaveBeenCalled()
+    expect(mockDrawFn).toHaveBeenCalled()
   })
 
   it('should error on build when `id` is omitted', () => {

--- a/src/drawings/circle/Circle.jsx
+++ b/src/drawings/circle/Circle.jsx
@@ -49,6 +49,7 @@ function drawAnimatedCircle (ctx, { drawState, setDrawState }) {
 }
 
 export const Circle = new CanvasBuilder()
+  .withId('AnimatedCircle')
   .withHeightAndWidth(HEIGHT, WIDTH)
   .withDrawFactory(drawAnimatedCircle)
   .withInitialDrawState(initialState)

--- a/src/drawings/example/Example.jsx
+++ b/src/drawings/example/Example.jsx
@@ -22,6 +22,7 @@ function drawExample (ctx) {
 }
 
 export const Example = new CanvasBuilder()
+  .withId('ExampleSquare')
   .withHeightAndWidth(HEIGHT, WIDTH)
   .withDrawFactory(drawExample)
   .build()

--- a/src/drawings/falling-ball/FallingBall.jsx
+++ b/src/drawings/falling-ball/FallingBall.jsx
@@ -55,6 +55,7 @@ function drawFallingBall (ctx) {
 }
 
 export const FallingBall = new CanvasBuilder()
+  .withId('FallingBall')
   .withHeightAndWidth(HEIGHT, WIDTH)
   .withDrawFactory(drawFallingBall)
   .build()


### PR DESCRIPTION
### What

Canvases must be built with `id`s now:

```js
new CanvasBuilder()
  .withId('SomeStringIdentifier')
  .withDrawFactory(someFactoryFunction)
  .build()
```

Canvases now have Aria `role='img'`. This seems to be a widely-accepted role for purely presentational canvases.

Built canvas components have some static properties that are handy for unit tests:
* `ariaRole`
* `id`
* `dataTestId`

And the `CanvasBuilder` finally has some unit tests :roll_eyes:  The tests check:
1. the build parameter validations.
2. that the resulting canvas component renders and is present in the document.
3. that the draw factory's `draw` method is called on render.