### PR TITLE
Get ball rolling

### DIFF
--- a/src/features/draw-rolling-circle/DrawRollingCircle.jsx
+++ b/src/features/draw-rolling-circle/DrawRollingCircle.jsx
@@ -18,15 +18,13 @@ export default function DrawRollingCircle () {
   return (
     <MainContainer>
       <ContentContainer>
-        <Drawing
-          isRollingCirclePaused={animationState.rollingCircle.isPaused}
-        />
-      </ContentContainer>
-
-      <ContentContainer>
         <p>
           <ActionSpan id='rollingCircle' text='Clicking here' onClick={togglePause} /> will animate the circle.
         </p>
+
+        <Drawing
+          isRollingCirclePaused={animationState.rollingCircle.isPaused}
+        />
       </ContentContainer>
     </MainContainer>
   )

--- a/src/features/draw-rolling-circle/Drawing.js
+++ b/src/features/draw-rolling-circle/Drawing.js
@@ -12,7 +12,7 @@ const initialState = {
     theta: Math.PI / 2,
     direction: 1,
     speed: Physics.VELOCITY,
-    centerX: radius,
+    centerX: radius + 1,
     centerY: HEIGHT - radius,
     cycloid: {
       plot: [{
@@ -52,7 +52,7 @@ function drawFactory (ctx, { drawState, setDrawState }) {
 
     // fill in background, just for reference
     ctx.fillStyle = Color.BLACK
-    ctx.strokeRect(0, 0, WIDTH, HEIGHT)
+    ctx.fillRect(0, 0, WIDTH, HEIGHT)
 
     // draw the base circle
     ctx.beginPath()

--- a/src/features/draw-rolling-circle/Drawing.js
+++ b/src/features/draw-rolling-circle/Drawing.js
@@ -12,7 +12,7 @@ const initialState = {
     theta: Math.PI / 2,
     direction: 1,
     speed: Physics.VELOCITY,
-    centerX: radius + 1,
+    centerX: radius,
     centerY: HEIGHT - radius,
     cycloid: {
       plot: [{
@@ -43,8 +43,11 @@ function drawFactory (ctx, { drawState, setDrawState }) {
   function draw (drawArgs) {
     const { isRollingCirclePaused } = drawArgs
 
-    if (rollingCircle.centerX >= WIDTH - radius || rollingCircle.centerX <= radius) {
-      rollingCircle.direction *= -1
+    if (rollingCircle.centerX >= WIDTH - radius) {
+      rollingCircle.direction = -1
+    }
+    if (rollingCircle.centerX <= radius) {
+      rollingCircle.direction = 1
     }
 
     ctx.clearRect(0, 0, WIDTH, HEIGHT)


### PR DESCRIPTION
This PR does 3 small things:

1. starts the circle's X position +1 canvas pixel farther to the right. This appears to solve the initial _getting stuck_ problem.
2. makes the canvas background black (`fillRect`), which seemed to be the intent (or I am misreading the comment).
3. stacks the page elements vertically, so there's more room for the canvas.

![rolling](https://github.com/peterjmartinson/huygens-site/assets/17347977/11c3280d-7296-4a4f-97e0-781829bbaba1)
